### PR TITLE
Use materialized GPS minute view in API cache loading

### DIFF
--- a/src/main/java/ch/bus/gps/entity/GpsPointFilteredByMinute.java
+++ b/src/main/java/ch/bus/gps/entity/GpsPointFilteredByMinute.java
@@ -1,0 +1,59 @@
+package ch.bus.gps.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.locationtech.jts.geom.Point;
+
+@Entity
+@Table(name = "vm_gps_points_filtered_by_minute", schema = "public")
+public class GpsPointFilteredByMinute implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private Date minute;
+  private Double avgSpeed;
+  private Double avgSpeedError;
+  private Point coordinateAvgGeom;
+
+  @Id
+  @Column(name = "minute")
+  public Date getMinute() {
+    return minute;
+  }
+
+  public void setMinute(Date minute) {
+    this.minute = minute;
+  }
+
+  @Column(name = "avg_speed")
+  public Double getAvgSpeed() {
+    return avgSpeed;
+  }
+
+  public void setAvgSpeed(Double avgSpeed) {
+    this.avgSpeed = avgSpeed;
+  }
+
+  @Column(name = "avg_speed_error")
+  public Double getAvgSpeedError() {
+    return avgSpeedError;
+  }
+
+  public void setAvgSpeedError(Double avgSpeedError) {
+    this.avgSpeedError = avgSpeedError;
+  }
+
+  @Column(name = "coordinate_avg_geom", columnDefinition = "geometry")
+  public Point getCoordinateAvgGeom() {
+    return coordinateAvgGeom;
+  }
+
+  public void setCoordinateAvgGeom(Point coordinateAvgGeom) {
+    this.coordinateAvgGeom = coordinateAvgGeom;
+  }
+
+}

--- a/src/main/java/ch/bus/gps/repository/GpsPointFilteredByMinuteRepository.java
+++ b/src/main/java/ch/bus/gps/repository/GpsPointFilteredByMinuteRepository.java
@@ -1,0 +1,12 @@
+package ch.bus.gps.repository;
+
+import java.util.Date;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import ch.bus.gps.entity.GpsPointFilteredByMinute;
+
+public interface GpsPointFilteredByMinuteRepository
+    extends JpaRepository<GpsPointFilteredByMinute, Date> {
+
+  List<GpsPointFilteredByMinute> findAllByOrderByMinuteAsc();
+}

--- a/src/main/java/ch/bus/gps/service/GpsService.java
+++ b/src/main/java/ch/bus/gps/service/GpsService.java
@@ -16,7 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 import ch.bus.gps.component.GpsComponent;
 import ch.bus.gps.dto.GpsDTO;
 import ch.bus.gps.dto.SpeakingClockDTO;
+import ch.bus.gps.entity.GpsPointFilteredByMinute;
 import ch.bus.gps.entity.Pgps;
+import ch.bus.gps.repository.GpsPointFilteredByMinuteRepository;
 import ch.bus.gps.repository.PgpsRepository;
 
 @Service
@@ -29,6 +31,9 @@ public class GpsService {
 
   @Autowired
   private GpsComponent gpsComponent;
+
+  @Autowired
+  private GpsPointFilteredByMinuteRepository gpsPointFilteredByMinuteRepository;
 
   private static List<GpsDTO> CACHED_TRIPE = new ArrayList<>();
   private static boolean RUNNING = true;
@@ -115,22 +120,19 @@ public class GpsService {
   // At every hour.
   public void getAllInCache() {
 
-    List<Pgps> r = this.pgpsRepository.getLast(250000);
+    List<GpsPointFilteredByMinute> r =
+        this.gpsPointFilteredByMinuteRepository.findAllByOrderByMinuteAsc();
 
     List<GpsDTO> list = new ArrayList<>();
     GpsDTO gpsDTO;
 
-    int modulo = 1;
-    if (r.size() > 5000)
-      modulo = r.size() / 5000;
-
-
-    for (int i = 0; i < r.size(); i++) {
-      if (i % modulo != 0)
-        continue;
+    for (GpsPointFilteredByMinute point : r) {
       gpsDTO = new GpsDTO();
-      gpsDTO.setLatitude(r.get(i).getCoordinate().getX());
-      gpsDTO.setLongitude(r.get(i).getCoordinate().getY());
+      gpsDTO.setTime(point.getMinute());
+      gpsDTO.setSpeed(point.getAvgSpeed());
+      gpsDTO.setEps(point.getAvgSpeedError());
+      gpsDTO.setLatitude(point.getCoordinateAvgGeom().getX());
+      gpsDTO.setLongitude(point.getCoordinateAvgGeom().getY());
       list.add(gpsDTO);
     }
 

--- a/src/test/java/ch/bus/gps/service/GpsServiceTest.java
+++ b/src/test/java/ch/bus/gps/service/GpsServiceTest.java
@@ -1,0 +1,82 @@
+package ch.bus.gps.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ch.bus.gps.component.GpsComponent;
+import ch.bus.gps.dto.GpsDTO;
+import ch.bus.gps.entity.GpsPointFilteredByMinute;
+import ch.bus.gps.repository.GpsPointFilteredByMinuteRepository;
+import ch.bus.gps.repository.PgpsRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GpsServiceTest {
+
+  @Mock
+  private PgpsRepository pgpsRepository;
+
+  @Mock
+  private GpsComponent gpsComponent;
+
+  @Mock
+  private GpsPointFilteredByMinuteRepository gpsPointFilteredByMinuteRepository;
+
+  @InjectMocks
+  private GpsService gpsService;
+
+  @BeforeEach
+  void resetCache() {
+    gpsService.getAll().clear();
+  }
+
+  @Test
+  void getAllInCacheShouldLoadDtoFromMaterializedViewRepository() {
+    Point point = new GeometryFactory().createPoint(new Coordinate(6.14, 46.2));
+    GpsPointFilteredByMinute row = new GpsPointFilteredByMinute();
+    Date minute = new Date(1716111300000L);
+    row.setMinute(minute);
+    row.setAvgSpeed(11.2);
+    row.setAvgSpeedError(0.4);
+    row.setCoordinateAvgGeom(point);
+
+    when(gpsPointFilteredByMinuteRepository.findAllByOrderByMinuteAsc())
+        .thenReturn(Arrays.asList(row));
+
+    gpsService.getAllInCache();
+
+    List<GpsDTO> all = gpsService.getAll();
+    assertEquals(1, all.size());
+    assertEquals(minute, all.get(0).getTime());
+    assertEquals(11.2, all.get(0).getSpeed());
+    assertEquals(0.4, all.get(0).getEps());
+    assertEquals(6.14, all.get(0).getLatitude());
+    assertEquals(46.2, all.get(0).getLongitude());
+    verify(gpsPointFilteredByMinuteRepository, times(1)).findAllByOrderByMinuteAsc();
+  }
+
+  @Test
+  void getAllShouldReuseCacheWithoutReloadingRepository() {
+    when(gpsPointFilteredByMinuteRepository.findAllByOrderByMinuteAsc()).thenReturn(Arrays.asList());
+
+    gpsService.getAllInCache();
+    gpsService.getAll();
+    gpsService.getAll();
+
+    verify(gpsPointFilteredByMinuteRepository, times(1)).findAllByOrderByMinuteAsc();
+    assertTrue(gpsService.getAll().isEmpty());
+  }
+}


### PR DESCRIPTION
### Motivation
- Serve pre-aggregated, minute-granularity GPS points from the PostgreSQL materialized view `public.vm_gps_points_filtered_by_minute` so the API no longer needs to sample/limit raw points in Java.
- Reduce load and complexity in the application by relying on the DB to filter and average GPS values (speed, speed error and geometry).
- Preserve the existing REST/DTO contract and cache behavior so no frontend changes are required.

### Description
- Added a new JPA entity `GpsPointFilteredByMinute` mapped to `public.vm_gps_points_filtered_by_minute` with `minute` as the `@Id`, `avgSpeed`, `avgSpeedError`, and `coordinateAvgGeom` mapped as the same `Point` geometry type used elsewhere.
- Added `GpsPointFilteredByMinuteRepository` extending `JpaRepository` with `findAllByOrderByMinuteAsc()` to fetch view rows ordered by minute.
- Updated `GpsService` to inject the new repository and replaced the old raw-point sampling logic in `getAllInCache()` by loading rows from the materialized-view repository and mapping each row to `GpsDTO` (`time=minute`, `speed=avgSpeed`, `eps=avgSpeedError`, `latitude/longitude` from `coordinateAvgGeom`).
- Removed the Java-side modulo sampling/limitation code and kept `getAll()` signature and cache variable `CACHED_TRIPE` unchanged so API output/format remains compatible.
- Added unit tests `GpsServiceTest` to verify that `getAllInCache()` loads DTOs from the new repository and that `getAll()` reuses the cache without reloading the repository.

### Testing
- New Mockito-based unit tests were added under `src/test/java/ch/bus/gps/service/GpsServiceTest.java` to assert DTO mapping and cache reuse behavior; these tests were not executed to completion in this environment.
- Running `./mvnw test -q` failed with `Permission denied` because the wrapper is not executable in the current environment.
- Running `mvn test -q` failed due to a Maven parent POM resolution error (`org.springframework.boot:spring-boot-starter-parent:2.3.0.RELEASE`) caused by a remote repository (`spring-milestones`) returning `403 Forbidden`, so automated test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c2347a8c48326a0748aab7cb3e76f)