### PR TITLE
Add OpenStreetMap tile background to /api/gps/map.bmp

### DIFF
--- a/src/main/java/ch/bus/gps/controller/GpsController.java
+++ b/src/main/java/ch/bus/gps/controller/GpsController.java
@@ -8,6 +8,11 @@ import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import javax.imageio.ImageIO;
@@ -30,6 +35,12 @@ public class GpsController {
   private static final int INKPLATE_WIDTH = 1200;
   private static final int INKPLATE_HEIGHT = 825;
   private static final int IMAGE_MARGIN = 20;
+  private static final int TILE_SIZE = 256;
+  private static final int MIN_ZOOM = 0;
+  private static final int MAX_ZOOM = 19;
+  private static final String OSM_TILE_URL_TEMPLATE = "https://tile.openstreetmap.org/%d/%d/%d.png";
+  private static final Path OSM_TILE_CACHE_DIR =
+      Path.of(System.getProperty("java.io.tmpdir"), "osm-tile-cache");
 
   @Autowired
   private GpsService gpsService;
@@ -77,48 +88,13 @@ public class GpsController {
     graphics.setColor(Color.WHITE);
     graphics.fillRect(0, 0, INKPLATE_WIDTH, INKPLATE_HEIGHT);
 
-    this.drawGrid(graphics);
-
-    List<Point2D.Double> geoPoints = new ArrayList<>();
-    for (GpsDTO point : gpsPoints) {
-      if (point.getLatitude() != null && point.getLongitude() != null) {
-        geoPoints.add(new Point2D.Double(point.getLongitude(), point.getLatitude()));
-      }
-    }
+    List<Point2D.Double> geoPoints = this.extractGeoPoints(gpsPoints);
 
     if (!geoPoints.isEmpty()) {
-      double minX = geoPoints.stream().mapToDouble(Point2D.Double::getX).min().orElse(0D);
-      double maxX = geoPoints.stream().mapToDouble(Point2D.Double::getX).max().orElse(0D);
-      double minY = geoPoints.stream().mapToDouble(Point2D.Double::getY).min().orElse(0D);
-      double maxY = geoPoints.stream().mapToDouble(Point2D.Double::getY).max().orElse(0D);
-
-      double rangeX = Math.max(maxX - minX, 0.000001D);
-      double rangeY = Math.max(maxY - minY, 0.000001D);
-      double drawWidth = INKPLATE_WIDTH - (2.0D * IMAGE_MARGIN);
-      double drawHeight = INKPLATE_HEIGHT - (2.0D * IMAGE_MARGIN);
-
-      List<Point2D.Double> scaledPoints = new ArrayList<>();
-      for (Point2D.Double geoPoint : geoPoints) {
-        double x = IMAGE_MARGIN + ((geoPoint.getX() - minX) / rangeX) * drawWidth;
-        double y = IMAGE_MARGIN + ((maxY - geoPoint.getY()) / rangeY) * drawHeight;
-        scaledPoints.add(new Point2D.Double(x, y));
-      }
-
-      graphics.setColor(Color.BLACK);
-      graphics.setStroke(new BasicStroke(2f));
-
-      for (int i = 1; i < scaledPoints.size(); i++) {
-        Point2D.Double p1 = scaledPoints.get(i - 1);
-        Point2D.Double p2 = scaledPoints.get(i);
-        graphics.drawLine((int) Math.round(p1.getX()), (int) Math.round(p1.getY()),
-            (int) Math.round(p2.getX()), (int) Math.round(p2.getY()));
-      }
-
-      for (Point2D.Double point : scaledPoints) {
-        int x = (int) Math.round(point.getX());
-        int y = (int) Math.round(point.getY());
-        graphics.fillRect(x - 1, y - 1, 3, 3);
-      }
+      BBox bbox = this.computeExpandedBBox(geoPoints);
+      int zoom = this.computeBestZoom(bbox, INKPLATE_WIDTH, INKPLATE_HEIGHT, IMAGE_MARGIN);
+      this.drawOsmTiles(graphics, bbox, zoom);
+      this.drawTrack(graphics, geoPoints, bbox);
     }
 
     graphics.dispose();
@@ -127,17 +103,161 @@ public class GpsController {
     return outputStream.toByteArray();
   }
 
-  private void drawGrid(Graphics2D graphics) {
-    graphics.setColor(Color.LIGHT_GRAY);
-    graphics.setStroke(new BasicStroke(1f));
+  private List<Point2D.Double> extractGeoPoints(List<GpsDTO> gpsPoints) {
+    List<Point2D.Double> geoPoints = new ArrayList<>();
+    for (GpsDTO point : gpsPoints) {
+      if (point.getLatitude() != null && point.getLongitude() != null) {
+        geoPoints.add(new Point2D.Double(point.getLongitude(), point.getLatitude()));
+      }
+    }
+    return geoPoints;
+  }
 
-    int gridStep = 100;
-    for (int x = 0; x <= INKPLATE_WIDTH; x += gridStep) {
-      graphics.drawLine(x, 0, x, INKPLATE_HEIGHT);
+  private BBox computeExpandedBBox(List<Point2D.Double> geoPoints) {
+    double minLon = geoPoints.stream().mapToDouble(Point2D.Double::getX).min().orElse(0D);
+    double maxLon = geoPoints.stream().mapToDouble(Point2D.Double::getX).max().orElse(0D);
+    double minLat = geoPoints.stream().mapToDouble(Point2D.Double::getY).min().orElse(0D);
+    double maxLat = geoPoints.stream().mapToDouble(Point2D.Double::getY).max().orElse(0D);
+
+    double lonSpan = Math.max(maxLon - minLon, 0.0001D);
+    double latSpan = Math.max(maxLat - minLat, 0.0001D);
+
+    double lonMargin = lonSpan * 0.15D;
+    double latMargin = latSpan * 0.15D;
+
+    return new BBox(minLon - lonMargin, minLat - latMargin, maxLon + lonMargin, maxLat + latMargin);
+  }
+
+  private int computeBestZoom(BBox bbox, int imageWidth, int imageHeight, int margin) {
+    int drawableWidth = imageWidth - (2 * margin);
+    int drawableHeight = imageHeight - (2 * margin);
+
+    for (int zoom = MAX_ZOOM; zoom >= MIN_ZOOM; zoom--) {
+      double minX = lonToTileX(bbox.minLon, zoom);
+      double maxX = lonToTileX(bbox.maxLon, zoom);
+      double minY = latToTileY(bbox.maxLat, zoom);
+      double maxY = latToTileY(bbox.minLat, zoom);
+
+      double pixelWidth = Math.abs(maxX - minX) * TILE_SIZE;
+      double pixelHeight = Math.abs(maxY - minY) * TILE_SIZE;
+
+      if (pixelWidth <= drawableWidth && pixelHeight <= drawableHeight) {
+        return zoom;
+      }
     }
 
-    for (int y = 0; y <= INKPLATE_HEIGHT; y += gridStep) {
-      graphics.drawLine(0, y, INKPLATE_WIDTH, y);
+    return MIN_ZOOM;
+  }
+
+  private void drawOsmTiles(Graphics2D graphics, BBox bbox, int zoom) throws IOException {
+    double minTileX = lonToTileX(bbox.minLon, zoom);
+    double maxTileX = lonToTileX(bbox.maxLon, zoom);
+    double minTileY = latToTileY(bbox.maxLat, zoom);
+    double maxTileY = latToTileY(bbox.minLat, zoom);
+
+    double mapPixelWidth = (maxTileX - minTileX) * TILE_SIZE;
+    double mapPixelHeight = (maxTileY - minTileY) * TILE_SIZE;
+
+    double scaleX = (INKPLATE_WIDTH - (2.0D * IMAGE_MARGIN)) / mapPixelWidth;
+    double scaleY = (INKPLATE_HEIGHT - (2.0D * IMAGE_MARGIN)) / mapPixelHeight;
+    double scale = Math.min(scaleX, scaleY);
+
+    double xOffset = IMAGE_MARGIN + ((INKPLATE_WIDTH - (2.0D * IMAGE_MARGIN)) - (mapPixelWidth * scale)) / 2.0D;
+    double yOffset = IMAGE_MARGIN + ((INKPLATE_HEIGHT - (2.0D * IMAGE_MARGIN)) - (mapPixelHeight * scale)) / 2.0D;
+
+    int tileXStart = (int) Math.floor(minTileX);
+    int tileXEnd = (int) Math.floor(maxTileX);
+    int tileYStart = (int) Math.floor(minTileY);
+    int tileYEnd = (int) Math.floor(maxTileY);
+
+    for (int tileX = tileXStart; tileX <= tileXEnd; tileX++) {
+      for (int tileY = tileYStart; tileY <= tileYEnd; tileY++) {
+        BufferedImage tile = this.getTile(zoom, tileX, tileY);
+        if (tile == null) {
+          continue;
+        }
+
+        double drawX = xOffset + ((tileX - minTileX) * TILE_SIZE * scale);
+        double drawY = yOffset + ((tileY - minTileY) * TILE_SIZE * scale);
+        int drawSize = (int) Math.ceil(TILE_SIZE * scale);
+
+        graphics.drawImage(tile, (int) Math.round(drawX), (int) Math.round(drawY), drawSize, drawSize,
+            null);
+      }
+    }
+  }
+
+  private void drawTrack(Graphics2D graphics, List<Point2D.Double> geoPoints, BBox bbox) {
+    graphics.setColor(Color.BLACK);
+    graphics.setStroke(new BasicStroke(2f));
+
+    double drawWidth = INKPLATE_WIDTH - (2.0D * IMAGE_MARGIN);
+    double drawHeight = INKPLATE_HEIGHT - (2.0D * IMAGE_MARGIN);
+    double lonRange = Math.max(bbox.maxLon - bbox.minLon, 0.000001D);
+    double latRange = Math.max(bbox.maxLat - bbox.minLat, 0.000001D);
+
+    List<Point2D.Double> scaledPoints = new ArrayList<>();
+    for (Point2D.Double geoPoint : geoPoints) {
+      double x = IMAGE_MARGIN + ((geoPoint.getX() - bbox.minLon) / lonRange) * drawWidth;
+      double y = IMAGE_MARGIN + ((bbox.maxLat - geoPoint.getY()) / latRange) * drawHeight;
+      scaledPoints.add(new Point2D.Double(x, y));
+    }
+
+    for (int i = 1; i < scaledPoints.size(); i++) {
+      Point2D.Double p1 = scaledPoints.get(i - 1);
+      Point2D.Double p2 = scaledPoints.get(i);
+      graphics.drawLine((int) Math.round(p1.getX()), (int) Math.round(p1.getY()),
+          (int) Math.round(p2.getX()), (int) Math.round(p2.getY()));
+    }
+
+    for (Point2D.Double point : scaledPoints) {
+      int x = (int) Math.round(point.getX());
+      int y = (int) Math.round(point.getY());
+      graphics.fillRect(x - 1, y - 1, 3, 3);
+    }
+  }
+
+  private BufferedImage getTile(int zoom, int x, int y) throws IOException {
+    int maxTileIndex = (1 << zoom) - 1;
+    if (x < 0 || y < 0 || x > maxTileIndex || y > maxTileIndex) {
+      return null;
+    }
+
+    Path tilePath = OSM_TILE_CACHE_DIR.resolve(Path.of(Integer.toString(zoom), Integer.toString(x), y + ".png"));
+
+    if (!Files.exists(tilePath)) {
+      Files.createDirectories(tilePath.getParent());
+      URL url = new URL(String.format(OSM_TILE_URL_TEMPLATE, zoom, x, y));
+      try (InputStream inputStream = url.openStream()) {
+        Files.copy(inputStream, tilePath, StandardCopyOption.REPLACE_EXISTING);
+      }
+    }
+
+    return ImageIO.read(tilePath.toFile());
+  }
+
+  private static double lonToTileX(double lon, int zoom) {
+    return (lon + 180.0D) / 360.0D * (1 << zoom);
+  }
+
+  private static double latToTileY(double lat, int zoom) {
+    double clampedLat = Math.max(-85.05112878D, Math.min(85.05112878D, lat));
+    double latRad = Math.toRadians(clampedLat);
+    return (1.0D - Math.log(Math.tan(latRad) + (1.0D / Math.cos(latRad))) / Math.PI) / 2.0D
+        * (1 << zoom);
+  }
+
+  private static class BBox {
+    private final double minLon;
+    private final double minLat;
+    private final double maxLon;
+    private final double maxLat;
+
+    private BBox(double minLon, double minLat, double maxLon, double maxLat) {
+      this.minLon = minLon;
+      this.minLat = minLat;
+      this.maxLon = maxLon;
+      this.maxLat = maxLat;
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Remplacer la grille synthétique par un vrai fond de carte OpenStreetMap pour rendre la représentation GPS plus utile et visuelle.
- Conserver la même source de données pour l’endpoint (`this.gpsService.getAll()`) et ne pas toucher à l’accès base de données.
- Adapter le rendu à l’écran Inkplate 10 (dimensions et sortie BMP 1-bit).

### Description
- Extraction des points `lat/lon` depuis les `GpsDTO`, calcul d’une bounding box avec marge de 15 % et choix d’un zoom OSM adapté à la zone et à la taille de l’écran.
- Téléchargement et composition des tuiles OSM `https://tile.openstreetmap.org/{z}/{x}/{y}.png`, rendu des tuiles sur le `BufferedImage` et centrage/mise à l’échelle pour la zone utile.
- Ajout d’un cache local de tuiles sur le filesystem (`java.io.tmpdir/osm-tile-cache`) pour éviter de retélécharger les tuiles à chaque appel.
- Dessin de la trace GPS en noir par-dessus la carte et conservation de la sortie en BMP 1-bit (`BufferedImage.TYPE_BYTE_BINARY`) avec `Content-Type: image/bmp`.

### Testing
- Tentative d’exécution `./mvnw -q -DskipTests compile` échouée à cause d’un wrapper non exécutable / absent dans l’environnement (permission / fichiers manquants).
- Tentative `sh mvnw -q -DskipTests compile` échouée à cause de fichiers Maven wrapper manquants dans `.mvn/wrapper`.
- Tentative `mvn -q -DskipTests compile` échouée à cause d’un parent POM Spring non résoluble (dépôt distant renvoie HTTP 403), donc compilation non validée ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c309183e083269d168c38a5b31a2e)