### PR TITLE
Amélioration de la quantification du contraste pour la carte e‑paper (/api/gps/map.bmp)

### DIFF
--- a/src/main/java/ch/bus/gps/controller/GpsController.java
+++ b/src/main/java/ch/bus/gps/controller/GpsController.java
@@ -42,6 +42,11 @@ public class GpsController {
   private static final int TILE_SIZE = 256;
   private static final int MIN_ZOOM = 0;
   private static final int MAX_ZOOM = 19;
+  private static final int MAP_WHITE_THRESHOLD = 245;
+  private static final int MAP_LIGHT_GRAY_THRESHOLD = 220;
+  private static final int MAP_MEDIUM_GRAY_THRESHOLD = 190;
+  private static final int MAP_LABEL_THRESHOLD = 160;
+  private static final int MAP_DARK_THRESHOLD = 120;
   private static final Logger LOGGER = LoggerFactory.getLogger(GpsController.class);
   private static final long MIN_VALID_TILE_FILE_SIZE_BYTES = 200L;
 
@@ -150,41 +155,25 @@ public class GpsController {
   }
 
   private void simplifyMapForEpaper(BufferedImage image) {
-
     for (int y = 0; y < image.getHeight(); y++) {
-
       for (int x = 0; x < image.getWidth(); x++) {
-
         Color c = new Color(image.getRGB(x, y));
 
         int gray = (int) ((c.getRed() * 0.299) + (c.getGreen() * 0.587) + (c.getBlue() * 0.114));
 
-        // Éclaircit fortement le fond
-        gray += 70;
-
-        // Clamp
-        gray = Math.max(0, Math.min(255, gray));
-
         int out;
-
-        // Routes principales / textes
-        if (gray < 110) {
-          out = 0;
-        }
-
-        // Routes secondaires
-        else if (gray < 170) {
-          out = 120;
-        }
-
-        // Fond très clair
-        else if (gray < 220) {
-          out = 235;
-        }
-
-        // Blanc
-        else {
+        if (gray > MAP_WHITE_THRESHOLD) {
           out = 255;
+        } else if (gray > MAP_LIGHT_GRAY_THRESHOLD) {
+          out = 245;
+        } else if (gray > MAP_MEDIUM_GRAY_THRESHOLD) {
+          out = 220;
+        } else if (gray > MAP_LABEL_THRESHOLD) {
+          out = 170;
+        } else if (gray > MAP_DARK_THRESHOLD) {
+          out = 90;
+        } else {
+          out = 0;
         }
 
         image.setRGB(x, y, new Color(out, out, out).getRGB());


### PR DESCRIPTION
### Motivation
- Rendre le fond de carte plus lisible sur Inkplate 10 en renforçant le contraste des labels, routes principales et éléments sombres sans charger le fond.
- Remplacer l’éclaircissement uniforme qui rendait les textes presque invisibles par une courbe de contraste ciblée pour préserver les labels OSM/CartoDB.

### Description
- Remplacement de l’éclaircissement `gray += 70` par une quantification par paliers basée sur la luminance pondérée dans `simplifyMapForEpaper(BufferedImage image)`.
- Ajout des constantes configurables en haut de la classe : `MAP_WHITE_THRESHOLD`, `MAP_LIGHT_GRAY_THRESHOLD`, `MAP_MEDIUM_GRAY_THRESHOLD`, `MAP_LABEL_THRESHOLD`, et `MAP_DARK_THRESHOLD`.
- Logique de sortie en niveaux : blanc pur pour les pixels très clairs, paliers intermédiaires pour renforcer les textes/routes, et noir pur pour les éléments sombres.
- Le pipeline de rendu reste inchangé et la méthode `simplifyMapForEpaper` est appelée entre `drawOsmTiles()` et `drawTrack()` pour garantir que la trace GPS reste dessinée en noir pur au-dessus.

### Testing
- Tentative d’un build rapide avec `./mvnw -q -DskipTests compile` échouée pour raisons d’environnement (`Permission denied` sur le wrapper). 
- Tentative d’un build Maven avec `mvn -q -DskipTests compile` échouée pour résolution de dépendances externes (parent POM Spring Boot inaccessible : HTTP 403 depuis `https://repo.spring.io/milestone`).
- Aucune suite de tests automatisés n’a pu être exécutée avec succès dans cet environnement; les modifications sont limitées à `simplifyMapForEpaper` et peuvent être testées manuellement ou via build CI une fois la résolution des dépendances rétablie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c51f55c48832698dab1f1cae5418c)